### PR TITLE
rttr_cast fix

### DIFF
--- a/src/rttr/detail/impl/rttr_cast_impl.h
+++ b/src/rttr/detail/impl/rttr_cast_impl.h
@@ -54,6 +54,12 @@ RTTR_INLINE Target_Type rttr_cast(Source_Type object) RTTR_NOEXCEPT
                    (!std::is_const<Arg_Type>::value && std::is_const<Return_Type>::value) ||
                    (!std::is_const<Arg_Type>::value && !std::is_const<Return_Type>::value), "Return type must have const qualifier");
 
+    // rttr_cast should return nullptr if input is nullptr
+    if (object == nullptr)
+    {
+        return nullptr;
+    }
+
     using source_type_no_cv = typename std::remove_cv<typename std::remove_pointer<Source_Type>::type>::type;
     return static_cast<Target_Type>(type::apply_offset(const_cast<source_type_no_cv*>(object)->get_ptr(), const_cast<source_type_no_cv*>(object)->get_type(), type::get<Target_Type>()));
 }

--- a/src/unit_tests/type/test_type.cpp
+++ b/src/unit_tests/type/test_type.cpp
@@ -254,6 +254,12 @@ TEST_CASE("Test rttr::type - MultipleClassInheritance", "[type]")
 
         CHECK(rttr_cast<ClassMultipleBaseE*>(&classMulti1E) != nullptr);
         CHECK(rttr_cast<ClassMultiple1E*>(&classMulti1E) != nullptr);
+
+        // check for nullptr, should always return nullptr
+        ClassMultipleBaseA* baseMultiANull = nullptr;             
+        CHECK(rttr_cast<ClassMultiple4B*>(baseMultiANull) == nullptr);
+        CHECK(rttr_cast<ClassMultiple5A*>(baseMultiANull) == nullptr);
+        CHECK(rttr_cast<ClassMultiple1E*>(baseMultiANull) == nullptr);
     }
 }
 


### PR DESCRIPTION
This fixes the rttr_cast so if passed a nullptr, it will always return a nullptr