### PR TITLE
Add RTLD_GLOBAL flag while loading libraries

### DIFF
--- a/src/rttr/detail/library/library_unix.cpp
+++ b/src/rttr/detail/library/library_unix.cpp
@@ -119,7 +119,7 @@ bool library_private::load_native()
         prefix_list.push_back(std::string());
     }
 
-    int dl_flags = RTLD_NOW;
+    int dl_flags = RTLD_NOW | RTLD_GLOBAL;
     auto retry = true;
     std::string attempt;
 


### PR DESCRIPTION
Allow symbols exported by this library and dependencies to be used by other loaded libraries.