### PR TITLE
Add support for extracting reference argument from variant

### DIFF
--- a/src/rttr/detail/variant/variant_data_policy.h
+++ b/src/rttr/detail/variant/variant_data_policy.h
@@ -38,7 +38,6 @@
 #include "rttr/detail/comparison/compare_less.h"
 
 #include <cstdint>
-
 namespace rttr
 {
 namespace detail
@@ -123,6 +122,7 @@ enum class variant_policy_operation : uint8_t
     SWAP,
     EXTRACT_WRAPPED_VALUE,
     CREATE_WRAPPED_VALUE,
+    EXTRACT_REFERENCE_ARGUMENT,
     GET_VALUE,
     GET_TYPE,
     GET_PTR,
@@ -192,6 +192,61 @@ enable_if_t<!is_copyable<Tp>::value ||
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename>
+std::false_type is_pointer_like (unsigned long);
+
+template <typename T>
+auto is_pointer_like (int)
+   -> decltype( * std::declval<T>(), std::true_type{} );
+
+template <typename T>
+auto is_pointer_like (long)
+   -> decltype( std::declval<T>().operator->(), std::true_type{} );
+
+template <typename T>
+using is_dereferenceable = decltype(is_pointer_like<T>(0));
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T, typename Tp = decay_except_array_t<wrapper_mapper_t<T>> >
+enable_if_t<is_wrapper<T>::value && is_dereferenceable<Tp>::value, argument> get_reference_argument(T& value)
+{
+    using raw_wrapper_type = remove_cv_t<remove_reference_t<T>>;
+    return argument(*(wrapper_mapper<raw_wrapper_type>::get(value)));
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T, typename Tp = decay_except_array_t<wrapper_mapper_t<T>> >
+enable_if_t<is_wrapper<T>::value && !is_dereferenceable<Tp>::value, argument> get_reference_argument(T& value)
+{
+    using raw_wrapper_type = remove_cv_t<remove_reference_t<T>>;
+    return argument(wrapper_mapper<raw_wrapper_type>::get(value));
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+enable_if_t<!is_wrapper<T>::value && 
+            is_dereferenceable<T>::value, argument> get_reference_argument(T& value)
+{ 
+    return argument(*value);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
+template<typename T>
+enable_if_t<!is_wrapper<T>::value &&
+            !is_dereferenceable<T>::value, argument> get_reference_argument(T& value)
+{
+    return argument(value);
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////
 
 /*!
  * This class represents the base implementation for variant_data policy.
@@ -225,6 +280,11 @@ struct variant_data_base_policy
             case variant_policy_operation::EXTRACT_WRAPPED_VALUE:
             {
                 arg.get_value<variant>() = get_wrapped_value(Tp::get_value(src_data));
+                break;
+            }
+            case variant_policy_operation::EXTRACT_REFERENCE_ARGUMENT:
+            {       
+                arg.get_value<argument&>() = get_reference_argument(Tp::get_value(src_data));
                 break;
             }
             case variant_policy_operation::CREATE_WRAPPED_VALUE:
@@ -610,6 +670,7 @@ struct RTTR_API variant_data_policy_empty
             case variant_policy_operation::CLONE:
             case variant_policy_operation::SWAP:
             case variant_policy_operation::EXTRACT_WRAPPED_VALUE:
+            case variant_policy_operation::EXTRACT_REFERENCE_ARGUMENT:
             case variant_policy_operation::CREATE_WRAPPED_VALUE:
             {
                 break;
@@ -718,6 +779,7 @@ struct RTTR_API variant_data_policy_void
             case variant_policy_operation::CLONE:
             case variant_policy_operation::SWAP:
             case variant_policy_operation::EXTRACT_WRAPPED_VALUE:
+            case variant_policy_operation::EXTRACT_REFERENCE_ARGUMENT:
             {
                 break;
             }
@@ -867,6 +929,7 @@ struct RTTR_API variant_data_policy_nullptr_t
             {
                 return false;
             }
+            case variant_policy_operation::EXTRACT_REFERENCE_ARGUMENT:
             case variant_policy_operation::EXTRACT_WRAPPED_VALUE:
             {
                 break;

--- a/src/rttr/variant.cpp
+++ b/src/rttr/variant.cpp
@@ -191,6 +191,15 @@ variant variant::extract_wrapped_value() const
 
 /////////////////////////////////////////////////////////////////////////////////////////
 
+argument variant::extract_reference_argument() const
+{
+    argument var;
+    m_policy(detail::variant_policy_operation::EXTRACT_REFERENCE_ARGUMENT, m_data, var);
+    return var;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 variant variant::create_wrapped_value(const type& wrapped_type) const
 {
     variant var;

--- a/src/rttr/variant.h
+++ b/src/rttr/variant.h
@@ -512,6 +512,16 @@ class RTTR_API variant
         variant extract_wrapped_value() const;
 
         /*!
+        * \brief Extracts the wrapped value as a reference and stores it as a reference in a new argument.
+        *
+        * \remark This can be used to extract values from a variant that can not usually be stored in a variant
+        *         such as references. It is non-templated equivalent to the get_wrapped_value function.
+        *
+        * \return An argument containing a reference to the stored wrapped value.
+        */
+        argument extract_reference_argument() const;
+
+        /*!
          * \brief Returns `true` if the contained value can be converted to the given type \p T.
          *        Otherwise `false`.
          *

--- a/src/unit_tests/variant/variant_misc_test.cpp
+++ b/src/unit_tests/variant/variant_misc_test.cpp
@@ -168,3 +168,61 @@ TEST_CASE("variant - get_wrapped_value", "[variant]")
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
+
+struct simple_type_noncopyable
+{
+  simple_type_noncopyable() {};
+  simple_type_noncopyable(const simple_type_noncopyable& other) = delete;
+};
+
+struct simple_type {
+
+};
+
+TEST_CASE("variant - get_reference_argument ")
+{
+  auto value = std::make_shared<simple_type_noncopyable>();
+
+  // works with shared_ptrs
+  variant var = value;
+  argument arg = var.extract_reference_argument();
+
+  CHECK(var.get_type().is_wrapper() == true);
+  CHECK(var.get_type().is_pointer() == false);
+  CHECK(arg.get_type().is_wrapper() == false);
+  CHECK(arg.get_type().is_pointer() == false);
+  REQUIRE(arg.get_type() == rttr::type::get<simple_type_noncopyable>());
+
+  // works with pointers
+  var = value.get();
+  arg = var.extract_reference_argument();
+
+  CHECK(var.get_type().is_wrapper() == false);
+  CHECK(var.get_type().is_pointer() == true);
+  CHECK(arg.get_type().is_wrapper() == false);
+  CHECK(arg.get_type().is_pointer() == false);
+  REQUIRE(arg.get_type() == rttr::type::get<simple_type_noncopyable>());
+
+  // works with reference wrappers
+  var = std::ref(*value);
+  arg = var.extract_reference_argument();
+
+  CHECK(var.get_type().is_wrapper() == true);
+  CHECK(var.get_type().is_pointer() == false);
+  CHECK(arg.get_type().is_wrapper() == false);
+  CHECK(arg.get_type().is_pointer() == false);
+  REQUIRE(arg.get_type() == rttr::type::get<simple_type_noncopyable>());
+
+  // works with values
+  auto simple_value = simple_type{};
+  var = simple_value;
+  arg = var.extract_reference_argument();
+
+  CHECK(var.get_type().is_wrapper() == false);
+  CHECK(var.get_type().is_pointer() == false);
+  CHECK(arg.get_type().is_wrapper() == false);
+  CHECK(arg.get_type().is_pointer() == false);
+  REQUIRE(arg.get_type() == rttr::type::get<simple_type>());
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently it is not possible to call a C++ method with a reference argument if you hold the argument value in a shared_ptr variant. This is needed for OMX since a lot of the shared_ptr usage in the API was removed and replaced with references

This adds a new method to the variant class called extract_reference_argument that supports extracting a reference value from a rttr::variant.

